### PR TITLE
Limit display of minutes

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,5 @@
+DontShowPostsBefore: 2016-08-01t00:00:00
+
 # Site settings
 title: "Bakersfield College Computer Science Club"
 description: "Meetings are held the first and third Fridays of the month in room B11 at 1pm"

--- a/util/allMinutes.html
+++ b/util/allMinutes.html
@@ -1,0 +1,18 @@
+---
+layout: default
+permalink: "/minutes/"
+---
+
+<div class="home">
+    {% assign minutes = site.posts %}
+    <h1 class="page-heading">Meeting Minutes</h1>
+    <ul class="post-list">
+        {% for post in minutes %}
+        <li>
+            <h2>
+                <a class="post-link" href="{{ post.url | prepend: site.baseurl }}">{{ post.date | date: "%B %-d, %Y" }}</a>
+            </h2>
+        </li>
+        {% endfor %}
+    </ul>
+</div>

--- a/util/index.html
+++ b/util/index.html
@@ -15,9 +15,11 @@ permalink: "/"
     </div>
     {% endif %}
 
+    {% assign DateLimit = "post.date > site.DontShowPostsBefore" %}
+    {% assign minutes = site.posts | where:"title","Minutes" | where_exp:"post",DateLimit %}
+    {% unless minutes == empty %}
     <h1 class="page-heading">Meeting Minutes</h1>
     <ul class="post-list">
-        {% assign minutes = (site.posts | where:"title","Minutes") %}
         {% for post in minutes %}
         <li>
             <h2>
@@ -26,4 +28,6 @@ permalink: "/"
         </li>
         {% endfor %}
     </ul>
+    {% endunless %}
+    <a href="/minutes/">View all previous minutes</a>
 </div>


### PR DESCRIPTION
This PR limits the homepage to displaying only the most recent ten minutes.

Ten was chosen arbitrarily; is there a better number?

As a supplement to this, should we create a new page that has *all* of the previous minutes?