### PR TITLE
Exclude vendor from build for CI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,3 +40,4 @@ exclude:
   - .gitignore
   - readme.md
   - script
+  - vendor


### PR DESCRIPTION
The `vendor` directory needs to be excluded from the build when doing CI tests.

See: https://jekyllrb.com/docs/continuous-integration/