### PR TITLE
Try to fix failing build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-DontShowPostsBefore: 2016-08-01t00:00:00
+DontShowPostsBefore: 2016-08-01t01:00:00.00-08:00
 
 # Site settings
 title: "Bakersfield College Computer Science Club"


### PR DESCRIPTION
Contacted GitHub support. Got this response:

> Thanks for getting in touch. Looking on our end, I'm seeing this error:
> ```text
 Liquid Exception: Liquid error (line 14): comparison of Time with String failed in util/index.html
             Fatal: Liquid::ArgumentError
                    Liquid error (line 14): comparison of Time with String failed
```
> Does that help? If you have any questions, please let me know!

So, I have to convince Safe YAML that `site.DontShowPostsBefore` really is a `Time` rather than a String. Hopefully _this_ works.