### PR TITLE
Removing Listen in on the Conference Call: 1-(712) 770-4700 Participa…

### DIFF
--- a/_layouts/agenda.html
+++ b/_layouts/agenda.html
@@ -12,7 +12,6 @@ layout: default
   </article>
   <footer>
     <p>Notes:</p>
-    <p>Listen in on the Conference Call: 1-(712) 770-4700 Participant passcode: 991468</p>
     <p>In accordance with the Ralph M. Brown Act, agendas are posted 72 hours before the meeting commences.</p>
     <p>Agendas are posted electronically at <a ref="https://aicsc.github.io">aicsc.github.io</a></p>
     <p>If you would like a copy of any of the agenda items listed, please email <a ref="mailto:bccompsciclub@gmail.com">bccompsciclub@gmail.com</a></p>


### PR DESCRIPTION
To address a posted issue: https://github.com/AICSC/aicsc.github.io/issues/70

Removing "Listen in on the Conference Call: 1-(712) 770-4700 Participant passcode: 991468" from our agenda footer as we no longer offer this resource for club members who are not at club meetings. 

-Reason: 
Resource no longer available to us. 